### PR TITLE
fix:拒绝权限后在后续判断中以为权限通过，然后执行无权限操作导致崩溃的问题

### DIFF
--- a/album/src/main/java/com/yanzhenjie/album/mvp/BaseActivity.java
+++ b/album/src/main/java/com/yanzhenjie/album/mvp/BaseActivity.java
@@ -68,7 +68,7 @@ public class BaseActivity extends AppCompatActivity implements Bye {
 
     @Override
     public final void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (isGrantedResult(requestCode)) onPermissionGranted(requestCode);
+        if (isGrantedResult(grantResults)) onPermissionGranted(requestCode);
         else onPermissionDenied(requestCode);
     }
 


### PR DESCRIPTION
Signed-off-by: lishengjie <416756910@qq.com>

在Album的module中的BaseActivity
调用了isGrantedResult(requestCode)
应该是isGrantedResult(grantResults)
不然就算拒绝了，按照现有的逻辑，也会走onPermissionGranted
然后造成崩溃