### PR TITLE
修复权限请求结果判断的问题

### DIFF
--- a/album/src/main/java/com/yanzhenjie/album/mvp/BaseActivity.java
+++ b/album/src/main/java/com/yanzhenjie/album/mvp/BaseActivity.java
@@ -68,7 +68,7 @@ public class BaseActivity extends AppCompatActivity implements Bye {
 
     @Override
     public final void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (isGrantedResult(requestCode)) onPermissionGranted(requestCode);
+        if (isGrantedResult(grantResults)) onPermissionGranted(requestCode);
         else onPermissionDenied(requestCode);
     }
 


### PR DESCRIPTION
点击拍照的时候，拒绝相机权限，应用奔溃，log如下：
    java.lang.RuntimeException: Failure delivering result ResultInfo{who=@android:requestPermissions:, request=1, result=-1, data=Intent { act=android.content.pm.action.REQUEST_PERMISSIONS (has extras) }} to activity {com.wondertek.paper/com.yanzhenjie.album.app.camera.CameraActivity}: java.lang.SecurityException: Permission Denial: starting Intent { act=android.media.action.IMAGE_CAPTURE flg=0x3 cmp=com.android.camera2/com.android.camera.CaptureActivity clip={text/uri-list U:content://com.wondertek.paper.app.file.provider/external_path/DCIM/20181103_021338285_dbbf9f288284a23a07e5f6f7111648ce.jpg} (has extras) } from ProcessRecord{21b5305 4814:com.wondertek.paper/u0a89} (pid=4814, uid=10089) with revoked permission android.permission.CAMERA