### PR TITLE
    Fix crash issue #221,#250;

### DIFF
--- a/album/src/main/java/com/yanzhenjie/album/app/album/AlbumActivity.java
+++ b/album/src/main/java/com/yanzhenjie/album/app/album/AlbumActivity.java
@@ -502,6 +502,11 @@ public class AlbumActivity extends BaseActivity implements
 
     @Override
     public void onPreviewChanged(AlbumFile albumFile) {
+        // finish button is pressed, ignore any preview change event.
+        // or mCheckedList will be changed AlbumActivity's thread and GalleryActivity thread.
+        if (isThumbnailTaskWorking) {
+            return;
+        }
         ArrayList<AlbumFile> albumFiles = mAlbumFolders.get(mCurrentFolder).getAlbumFiles();
         int position = albumFiles.indexOf(albumFile);
         int notifyPosition = mHasCamera ? position + 1 : position;
@@ -548,10 +553,12 @@ public class AlbumActivity extends BaseActivity implements
         callbackCancel();
     }
 
+    private boolean isThumbnailTaskWorking = false;
     /**
      * Callback result action.
      */
     private void callbackResult() {
+        isThumbnailTaskWorking = true;
         ThumbnailBuildTask task = new ThumbnailBuildTask(this, mCheckedList, this);
         task.execute();
     }
@@ -566,6 +573,7 @@ public class AlbumActivity extends BaseActivity implements
     public void onThumbnailCallback(ArrayList<AlbumFile> albumFiles) {
         if (sResult != null) sResult.onAction(albumFiles);
         dismissLoadingDialog();
+        isThumbnailTaskWorking = false;
         finish();
     }
 


### PR DESCRIPTION
    mCheckedList could be accessed in 2 threads, AlbumActivity and GalleryActivity(onPreviewChanged). AlbumActivity calls complete() and start new thread to generate thumbnail, while galleryactivity uncheck some file and change mCheckedList, then will crash.
    This change will not allow changing mCheckedList while thumbnail task is running.